### PR TITLE
Allow putting the player image on top of the stats bar.

### DIFF
--- a/src/config/playerInfo.ts
+++ b/src/config/playerInfo.ts
@@ -8,6 +8,10 @@ export interface PlayerInfo {
      */
     image?: string;
     /**
+     * Should the image be displayed inline
+     */
+    imageInline?: boolean;
+    /**
      * Fixed player name: will prevent using the GSI provided names.
      */
     name?: string;
@@ -20,6 +24,7 @@ export const playerInfoList: PlayerInfoList = {
     "76561198005627722": {
         twitterId: "@thiry_sk",
         image: "shroud.jpg",
+        imageInline: false,
         name: "Shroud",
     },
 };

--- a/src/container/container.tsx
+++ b/src/container/container.tsx
@@ -87,6 +87,7 @@ class ContainerPage extends React.Component<Props, ContainerState> {
                 name: this.props.spectatingPlayer.name,
                 twitterId: this.props.spectatingPlayer.twitterId,
                 image: this.props.spectatingPlayer.image,
+                imageInline: this.props.spectatingPlayer.imageInline,
                 activeWeapon: this.props.spectatingPlayer.weapons.activeWeapon,
                 flashBangAmount: this.props.spectatingPlayer.weapons.flashBangAmount,
                 smokeAmount: this.props.spectatingPlayer.weapons.smokeAmount,

--- a/src/redux/modules/spectatingPlayer/spectatingPlayer.ts
+++ b/src/redux/modules/spectatingPlayer/spectatingPlayer.ts
@@ -73,6 +73,7 @@ const initialState: SpectatingPlayerState = {
         },
         twitterId: null,
         image: null,
+        imageInline: null,
     },
 };
 

--- a/src/views/spectatingPlayer/SpectatingPlayer.tsx
+++ b/src/views/spectatingPlayer/SpectatingPlayer.tsx
@@ -26,6 +26,10 @@ export interface SpectatingPlayerProps {
      */
     image?: string;
     /**
+     * image_inline: Display the image inline or above the bar
+     */
+    imageInline?: boolean;
+    /**
      * アクティブ武器.
      */
     activeWeapon: WeaponInfo;
@@ -200,11 +204,12 @@ export class SpectatingPlayer extends BaseComponent<SpectatingPlayerProps, {}> {
                 className={classNames.spectatingPlayer}
                 data-show-spectating-player={this.props.showSpectatingPlayer}
                 data-has-player-image={playerImage !== null}
+                data-image-inline={this.props.imageInline}
             >
                 {this.props.image &&
                     <img
                         src={playerImage}
-                        className={classNames.playerImage}
+                        className={this.props.imageInline ? classNames.playerImage : classNames.spectatingPlayerImage}
                         data-team={this.props.team}
                     />
                 }

--- a/src/views/spectatingPlayer/Story.tsx
+++ b/src/views/spectatingPlayer/Story.tsx
@@ -3,11 +3,12 @@ import { storiesOf, Story } from "@storybook/react";
 import { GameStateIntegration } from "../../dataTypes";
 import { SpectatingPlayer, SpectatingPlayerProps } from "./SpectatingPlayer";
 
-export const props = (team: GameStateIntegration.Team, hasPlayerImage: boolean): SpectatingPlayerProps => ({
+export const props = (team: GameStateIntegration.Team, hasPlayerImage: boolean, inline: boolean = true): SpectatingPlayerProps => ({
     showSpectatingPlayer: true,
     name: "FooFooFooFooFooFooFooFooFooFooFooFooFooFooFooFooFooFooFooFooFooFooFoo",
     twitterId: "@thiry_sk",
     image: hasPlayerImage ? "shroud.jpg" : null,
+    imageInline: inline,
     activeWeapon: {
         name: "weapon_ak47",
         ammoClip: 29,
@@ -43,4 +44,7 @@ storiesOf("SpectatingPlayer", module)
     })
     .add("プレイヤー画像なしのTのSpectatingPlayer情報を表示できる", () => {
         return <SpectatingPlayer {...props(GameStateIntegration.Team.T, false)} />;
+    })
+    .add("Player images can be displayed on top", () => {
+        return <SpectatingPlayer {...props(GameStateIntegration.Team.T, true, false)} />;
     });

--- a/src/views/spectatingPlayer/spectating_player.scss
+++ b/src/views/spectatingPlayer/spectating_player.scss
@@ -1,22 +1,34 @@
 @import "../theme/color.scss";
 $sub-info-height: 25px;
+$bottom-padding: 100px;
+$spectating-box-height: 70px;
+
+.spectating-player-image {
+  width: auto;
+  height: 180px;
+  position: fixed;
+  bottom: $spectating-box-height;
+  left: 50%;
+  transform: translateX(-420px);
+}
+
 .spectating-player {
   composes: base from "../theme/common.scss";
   width: 920px;
-  height: 70px;
+  height: $spectating-box-height;
   position: fixed;
-  bottom: 100px;
+  bottom: $bottom-padding;
   left: 50%;
   transform: translateX(-50%);
   &[data-show-spectating-player=true] {
-    transition: all 1s;
-    opacity: 1;
+      transition: all 1s;
+      opacity: 1;
   }
   &[data-show-spectating-player=false] {
-    transition: all 1s;
-    opacity: 0;
+      transition: all 1s;
+      opacity: 0;
   }
-  &[data-has-player-image=true] {
+  &[data-has-player-image=true][data-image-inline=true]{
     width: 920px + 120px;
     height: 120px;
     &:after {


### PR DESCRIPTION
This allows the user to specify the `imageInline` property for each player information.

If this is set to `false` the image will be displayed on top of the status bar, otherwise it will use the already existing `inline` style to display it.

An example can be seen [here](https://i.imgur.com/YxQSPCR.jpg).

This might be considered a fix for #26 - however it can only switch between the two existing implementations and is not totally configurable.